### PR TITLE
Remove GuzzleHttp\Psr7\str() function

### DIFF
--- a/src/Yousign/YousignClient.php
+++ b/src/Yousign/YousignClient.php
@@ -6,8 +6,8 @@ namespace Yousign;
 
 use Exception;
 use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Message;
 use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Psr7;
 use Psr\Http\Message\ResponseInterface;
 
 /*
@@ -121,10 +121,10 @@ final class YousignClient
             $message = sprintf(
                 "%s\n%s\n",
                 $exception->getMessage(),
-                Psr7\str($exception->getRequest())
+                Message::toString($exception->getRequest())
             );
             if ($exception->hasResponse()) {
-                $message .= "\n" . Psr7\str($exception->getResponse());
+                $message .= "\n" . Message::toString($exception->getResponse());
             }
         } catch (Exception $exception) {
             $message = $exception->getMessage();


### PR DESCRIPTION
Since guzzle\psr7 has removed the `str()` function the YousignClient was not able to send request.

Replaced by `Message::toString` method according to [guzzle/psr7#345](https://github.com/guzzle/psr7/pull/345) then tests passed with no errors.

